### PR TITLE
Fix invalid escape sequence

### DIFF
--- a/scripts/collect_results.py
+++ b/scripts/collect_results.py
@@ -143,7 +143,7 @@ input_text = """\\bmtwentyfive & 19.2 & 27.1 & 14.9 & 12.5 & 13.5 & 16.5 & 15.2 
 
 df = []
 for x in input_text.split("\n"):
-    x = x.replace("\textbf{", "")
+    x = x.replace("\\textbf{", "")
     x = x.replace("\\underline{", "")
     x = x.replace("}", "")
     x = x.split("&")


### PR DESCRIPTION
While \t is legal in strings, it means a tab character - not a literal backslash and lowercase t (part of LaTeX syntax), as appears to have been intended.